### PR TITLE
Update resources-arsc.mdx

### DIFF
--- a/docs/advanced/resources-arsc.mdx
+++ b/docs/advanced/resources-arsc.mdx
@@ -94,7 +94,7 @@ end up at another new chunk. Below is the relevant segment after the String Pool
 
 - `]` - end of string pool.
 
-So if we read another `ResChunk_header` we get a new type of chunk. This chunk is a `RES_TABLE_TYPE` (`0x0200`) chunk
+So if we read another `ResChunk_header` we get a new type of chunk. This chunk is a `RES_TABLE_PACKAGE_TYPE` (`0x0200`) chunk
 which is described as:
 
 | Name                           | Size     | Description                                                                     |


### PR DESCRIPTION
Based on https://github.com/iBotPeaches/platform_frameworks_base/blob/main/libs/androidfw/include/androidfw/ResourceTypes.h#L251, this section of the arsc description references the `RES_TABLE_PACKAGE_TYPE` chunk type and not the `RES_TABLE_TYPE` chunk type.