### PR TITLE
docs: update changelog for 3.0.2

### DIFF
--- a/docs/unreleased.mdx
+++ b/docs/unreleased.mdx
@@ -8,6 +8,16 @@ The changelog of the upcoming release, subject to change prior to finalization.
 
 :::
 
+- [[#4113](https://github.com/iBotPeaches/Apktool/pull/4113)] ([CVE-2026-39973](https://github.com/iBotPeaches/Apktool/security/advisories/GHSA-m8mh-x359-vm8m)) - Validate type names to prevent arbitrary file writes. (Thanks IgorEisberg)
 - [[#4097](https://github.com/iBotPeaches/Apktool/pull/4097)] Fix validation format of incompatible item formats. (Thanks IgorEisberg)
+- [[#4128](https://github.com/iBotPeaches/Apktool/pull/4128)] Add loading of base/config APK as a library for split decoding. (Thanks IgorEisberg)
+- [[#4106](https://github.com/iBotPeaches/Apktool/pull/4106)] Add ability to return `ApkInfo` after decode. (Thanks amartinz)
+- [[#4120](https://github.com/iBotPeaches/Apktool/pull/4120)] Rename output jar with underscore to match helper scripts. (Thanks Copilot)
+- [[#4115](https://github.com/iBotPeaches/Apktool/pull/4115)] Improve performance of `resources.arsc` disassembly with buffered stream. (Thanks X1nto)
+- [[#4116](https://github.com/iBotPeaches/Apktool/pull/4116)] Improve performance of file disassembly with buffered streams. (Thanks IgorEisberg)
+- [[#4124](https://github.com/iBotPeaches/Apktool/pull/4124)] Improve performance of lookups in ResPackage behavior. (Thanks X1nto & IgorEisberg)
+- [[#4117](https://github.com/iBotPeaches/Apktool/pull/4117)] Internalize buffering to standardize flush behavior and improve performance. (Thanks IgorEisberg)
+- [[#4119](https://github.com/iBotPeaches/Apktool/pull/4119)] Upgrade internal aapt2 binaries to lessen restriction on Meta resource encoding.
 - [[#4100](https://github.com/iBotPeaches/Apktool/pull/4100)] Upgrade `upload-artifact` to `v7`.
-- [[#4101](https://github.com/iBotPeaches/Apktool/pull/4101)] Upgrade `gradle/actions` to `5.0.2`.
+- [[#4101](https://github.com/iBotPeaches/Apktool/pull/4101), [#4114](https://github.com/iBotPeaches/Apktool/pull/4114)] Upgrade `gradle/actions` to `6.1.0`.
+- [[#4109](https://github.com/iBotPeaches/Apktool/pull/4109)] Upgrade `r8` to `9.1.31`.


### PR DESCRIPTION
Was sleeping on changelog updates due to CVE. Incoming release.